### PR TITLE
Fix container style object merging

### DIFF
--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -131,7 +131,7 @@ export const createContainer = sizes => (
   {
     container: sizes.map(size =>
       wrapMedia(getMediaPortKey(size), {
-        width: CONTAINER_SIZES[size],
+        width: CONTAINER_SIZES[size] || 'initial',
         marginRight: 'auto',
         marginLeft: 'auto',
       }),

--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -124,16 +124,18 @@ export const createPositionColumns = (size, mediaKey) => (
 /**
  * Creates a container style element for a particular size
  * @function
- * @param  {String} size  the size to create the container for
+ * @param  {Array<String>} sizes  the sizes to create the container for
  * @return {Object}
  */
-export const createContainer = (size, mediaKey) => (
+export const createContainer = sizes => (
   {
-    container: wrapMedia(mediaKey, {
-      width: CONTAINER_SIZES[size],
-      marginRight: 'auto',
-      marginLeft: 'auto',
-    }),
+    container: sizes.map(size =>
+      wrapMedia(getMediaPortKey(size), {
+        width: CONTAINER_SIZES[size],
+        marginRight: 'auto',
+        marginLeft: 'auto',
+      }),
+    ).reduce(reduceStyles, {}),
   }
 );
 
@@ -151,7 +153,10 @@ export const createFlexColumns = (size) => {
       ...createOffsetColumn(size, col, mediaKey),
       ...createPositionColumns(size, mediaKey),
     }
-  )).reduce(reduceStyles, createContainer(size, mediaKey));
+  )).reduce(reduceStyles, {});
 };
 
-export default () => SIZES.map(size => createFlexColumns(size)).reduce(reduceStyles, MISC_STYLES);
+export default () =>
+    SIZES.map(createFlexColumns)
+    .concat([createContainer(SIZES)])
+    .reduce(reduceStyles, MISC_STYLES);


### PR DESCRIPTION
This fix #7 

Styles for container are generated differently. The other solution was to use a deep object merging library, but that would add a dependency.